### PR TITLE
Migrate to Monger

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,13 +5,11 @@
                  [stencil "0.2.0"]
                  [noir "1.3.0-beta10"]
                  [lib-noir "0.2.0-alpha1"]
-                 [congomongo "0.1.9"]
+                 [com.novemberain/monger "1.0.0"]
                  [clj-config "0.2.0"]
                  [clj-http "0.4.0"]
                  [clavatar "0.2.0"]
                  [clj-time "0.3.3"]
-                 [amalloy/mongo-session "0.0.2" :exclusions [ring/ring-core]]
-                 [conch "0.3.0"]
-                 [org.bovinegenius/exploding-fish "0.2.0"]]
+                 [conch "0.3.0"]]
   :main refheap.server)
 

--- a/src/refheap/models/api.clj
+++ b/src/refheap/models/api.clj
@@ -1,6 +1,5 @@
 (ns refheap.models.api
-  (:require [somnium.congomongo :as mongo]
-            [refheap.models.users :as users]
+  (:require [refheap.models.users :as users]
             [refheap.models.paste :as pastes]
             [noir.response :as response]
             [clojure.string :as string])

--- a/src/refheap/models/login.clj
+++ b/src/refheap/models/login.clj
@@ -1,6 +1,5 @@
 (ns refheap.models.login
   (:require [refheap.config :refer [config]]
-            [somnium.congomongo :as mongo]
             [clj-http.client :as http]
             [noir.session :as session]
             [cheshire.core :as json]

--- a/src/refheap/models/paste.clj
+++ b/src/refheap/models/paste.clj
@@ -1,6 +1,5 @@
 (ns refheap.models.paste 
-  (:require [somnium.congomongo :as mongo]
-            [noir.session :as session]
+  (:require [noir.session :as session]
             [clojure.java.io :as io]
             [clojure.string :as string]
             [clj-time.core :as time]

--- a/src/refheap/models/paste.clj
+++ b/src/refheap/models/paste.clj
@@ -1,4 +1,5 @@
-(ns refheap.models.paste 
+(ns refheap.models.paste
+  (:refer-clojure :exclude [sort find])
   (:require [noir.session :as session]
             [clojure.java.io :as io]
             [clojure.string :as string]
@@ -6,19 +7,22 @@
             [clj-time.format :as format]
             [conch.core :as sh]
             [refheap.dates :refer [parse-string]]
-            [refheap.messages :refer [error]])
-  (:import java.io.StringReader))
+            [refheap.messages :refer [error]]
+            [monger.collection :as mc]
+            [monger.query :refer [with-collection find sort limit skip]])
+  (:import java.io.StringReader
+           org.bson.types.ObjectId))
 
 (def paste-id
   "The current highest paste-id."
   (atom
-    (-> (mongo/fetch
-          :pastes
-          :sort {:id -1}
-          :limit 1)
-        first
-        :id
-        (or 0))))
+   (-> (with-collection "pastes"
+         (find {})
+         (sort {:id -1})
+         (limit 1))
+       first
+       :id
+       (or 0))))
 
 (def lexers
   "A map of language names to pygments lexer names."
@@ -214,15 +218,15 @@
   "Selects a language."
   [lang]
   (or
-    (if (and lang (.startsWith lang "."))
-      (first
-        (filter (fn [[_ v]]
-                  (when-let [exts (:exts v)]
-                    (exts (string/join (rest lang)))))
-                lexers))
-      (when-let [lang-map (lexers lang)]
-        [lang lang-map]))
-    ["Plain Text" {:short "text"}]))
+   (if (and lang (.startsWith lang "."))
+     (first
+      (filter (fn [[_ v]]
+                (when-let [exts (:exts v)]
+                  (exts (string/join (rest lang)))))
+              lexers))
+     (when-let [lang-map (lexers lang)]
+       [lang lang-map]))
+   ["Plain Text" {:short "text"}]))
 
 (defn pygmentize
   "Syntax highlight some code."
@@ -244,6 +248,7 @@
   (let [[name {:keys [short]}] (lookup-lexer language)]
     {:paste-id (str paste-id)
      :id id
+     :_id (ObjectId.)
      :user (:id user)
      :language name
      :raw-contents contents
@@ -259,9 +264,9 @@
 
 (defn validate [contents]
   (cond
-   (>= (count contents) 64000) {:error "That paste was too big. Has to be less than 64KB"}
-   (not (re-seq #"\S" (str contents))) {:error "Your paste cannot be empty."}
-   :else {:contents contents}))
+    (>= (count contents) 64000) {:error "That paste was too big. Has to be less than 64KB"}
+    (not (re-seq #"\S" (str contents))) {:error "Your paste cannot be empty."}
+    :else {:contents contents}))
 
 (defn parse-date [date]
   (format/parse))
@@ -273,36 +278,30 @@
     (if-let [error (:error validated)]
       error
       (let [id (swap! paste-id inc)
-            result (mongo/insert!
-                    :pastes
-                    (paste-map
-                     (when-not private id)
-                     id
-                     user
-                     language
-                     (:contents validated)
-                     (format/unparse (format/formatters :date-time) (time/now))
-                     private
-                     fork))]
+            doc    (paste-map (when-not private id)
+                              id
+                              user
+                              language
+                              (:contents validated)
+                              (format/unparse (format/formatters :date-time) (time/now))
+                              private
+                              fork)
+            result (mc/insert "pastes" doc)]
         (if private
           (let [new (assoc result :paste-id (str (:_id result)))]
-            (mongo/update! :pastes result new)
+            (mc/update "pastes" result new)
             new)
           result)))))
 
 (defn get-paste
   "Get a paste."
   [id]
-  (mongo/fetch-one
-   :pastes
-   :where {:paste-id id}))
+  (mc/find-one-as-map "pastes" {:paste-id id}))
 
 (defn get-paste-by-id
   "Get a paste by its :id key (which is the same regardless of being public or private."
   [id]
-  (mongo/fetch-one
-   :pastes
-   :where {:id id}))
+  (mc/find-one-as-map "pastes" {:id id}))
 
 (defn update-paste
   "Update an existing paste."
@@ -310,47 +309,48 @@
   (let [validated (validate contents)
         error (:error validated)]
     (cond
-     error error
-     (nil? user) "You must be logged in to edit pastes."
-     (not= (:id user) (:user old)) "You can only edit your own pastes!"
-     :else (let [old-private (:private old)
-                 new-private (boolean private)
-                 paste (paste-map
-                        (cond
-                         (= old-private new-private) (:paste-id old)
-                         (false? new-private) (:id old)
-                         (true? new-private) (str (:_id old)))
-                        (:id old)
-                        user
-                        language
-                        (:contents validated)
-                        (:date old)
-                        private
-                        (:fork old))]
-             (mongo/update! :pastes old paste)
-             paste))))
+      error error
+      (nil? user) "You must be logged in to edit pastes."
+      (not= (:id user) (:user old)) "You can only edit your own pastes!"
+      :else (let [old-private (:private old)
+                  new-private (boolean private)
+                  paste (paste-map
+                         (cond
+                           (= old-private new-private) (:paste-id old)
+                           (false? new-private) (:id old)
+                           (true? new-private) (str (:_id old)))
+                         (:id old)
+                         user
+                         language
+                         (:contents validated)
+                         (:date old)
+                         private
+                         (:fork old))]
+              (mc/update "pastes" old paste)
+              paste))))
 
 (defn delete-paste
   "Delete an existing paste."
   [id]
-  (mongo/destroy! :pastes {:paste-id id}))
+  (mc/remove "pastes" {:paste-id id}))
 
 (defn get-pastes
   "Get public pastes."
   [page]
-  (mongo/fetch
-   :pastes
-   :where {:private false}
-   :sort {:date -1}
-   :limit 20
-   :skip (* 20 (dec page))))
+  ;; TODO: monger.query provides proper pagination support, I think it
+  ;; makes sense to switch to that later. MK.
+  (with-collection "pastes"
+    (find {:private false})
+    (sort {:date -1})
+    (limit 20)
+    (skip (* 20 (dec page)))))
 
 (defn count-pastes
   "Count pastes."
   [& [private?]]
-  (mongo/fetch-count
-   :pastes
-   :where (when-not (nil? private?) {:private private?})))
+  (mc/count "pastes" (if-not (nil? private?)
+                       {:private private?}
+                       {})))
 
 (defn count-pages [n per]
   (long (Math/ceil (/ n per))))

--- a/src/refheap/models/paste.clj
+++ b/src/refheap/models/paste.clj
@@ -288,10 +288,10 @@
                               fork)
             result (mc/insert "pastes" doc)]
         (if private
-          (let [new (assoc result :paste-id (str (:_id result)))]
-            (mc/update "pastes" result new)
+          (let [new (assoc doc :paste-id (str (:_id doc)))]
+            (mc/update "pastes" doc new)
             new)
-          result)))))
+          doc)))))
 
 (defn get-paste
   "Get a paste."

--- a/src/refheap/models/users.clj
+++ b/src/refheap/models/users.clj
@@ -1,22 +1,22 @@
-(ns refheap.models.users)
+(ns refheap.models.users
+  (:refer-clojure :exclude [sort find])  
+  (:require [monger.collection :as mc]
+            [monger.query :refer [with-collection find sort limit skip]]))
 
 (defn get-user [user]
-  (mongo/fetch-one
-   :users
-   :where {:username user}))
+  (mc/find-one-as-map "users" {:username user}))
 
 (defn get-user-by-id [id]
-  (mongo/fetch-by-id :users (mongo/object-id id)))
+  ;; Monger takes care of coercing strings to object ids if necessary.
+  (mc/find-map-by-id "users" id))
 
 (defn user-pastes [user page & [others]]
-  (mongo/fetch
-   :pastes
-   :where (merge {:user (str (:_id (get-user user)))} others)
-   :sort {:date -1}
-   :limit 10
-   :skip (* 10 (dec page))))
+  (with-collection "users"
+    (find (merge {:user (str (:_id (get-user user)))} others))
+    (sort {:date -1})
+    (limit 10)
+    ;; TODO: switch to Monger's pagination support. MK.
+    (skip (* 10 (dec page)))))
 
 (defn count-user-pastes [user & [others]]
-  (mongo/fetch-count
-   :pastes
-   :where (merge {:user (str (:_id (get-user user)))} others)))
+  (mc/count "pastes" (merge {:user (str (:_id (get-user user)))} others)))

--- a/src/refheap/models/users.clj
+++ b/src/refheap/models/users.clj
@@ -1,5 +1,4 @@
-(ns refheap.models.users
-  (:require [somnium.congomongo :as mongo]))
+(ns refheap.models.users)
 
 (defn get-user [user]
   (mongo/fetch-one

--- a/src/refheap/server.clj
+++ b/src/refheap/server.clj
@@ -1,17 +1,13 @@
 (ns refheap.server
   (:require [refheap.config :refer [config]]
-            [refheap.middleware :as middleware]
-            [mongo-session.core :refer [mongo-session]]
             [noir.server :as server]
-            [somnium.congomongo :as mongo]
-            [org.bovinegenius.exploding-fish :as uri]
             [noir.trailing-slash :refer [wrap-strip-trailing-slash]]
             [noir.canonical-host :refer [wrap-canonical-host]]
-            [noir.force-ssl :refer [wrap-force-ssl]]))
+            [noir.force-ssl :refer [wrap-force-ssl]]
+            [monger.ring.session-store :refer [monger-store]]))
 
 (defn mongolab-info []
-  (when-let [env (System/getenv "MONGOLAB_URI")]
-    (uri/uri env)))
+  (System/getenv "MONGOLAB_URI"))
 
 (let [{:keys [path port host user-info]} (mongolab-info)
       [user pass] (and user-info (.split user-info ":"))
@@ -38,5 +34,5 @@
       (server/add-middleware wrap-force-ssl))
     (server/start port {:mode mode
                         :ns 'refheap
-                        :session-store (mongo-session :sessions)})))
+                        :session-store (monger-store :sessions)})))
 

--- a/src/refheap/server.clj
+++ b/src/refheap/server.clj
@@ -4,24 +4,17 @@
             [noir.trailing-slash :refer [wrap-strip-trailing-slash]]
             [noir.canonical-host :refer [wrap-canonical-host]]
             [noir.force-ssl :refer [wrap-force-ssl]]
+            [monger.core :as mg]
+            [monger.collection :as mc]
             [monger.ring.session-store :refer [monger-store]]))
 
-(defn mongolab-info []
-  (System/getenv "MONGOLAB_URI"))
+(let [uri (get (System/getenv) "MONGOLAB_URI" "mongodb://127.0.0.1/refheap_development")]
+  (mg/connect-via-uri! uri))
 
-(let [{:keys [path port host user-info]} (mongolab-info)
-      [user pass] (and user-info (.split user-info ":"))
-      connection (mongo/make-connection (if path (subs path 1) (config :db-name)) 
-                                        :host (or host (config :db-host)) 
-                                        :port (Integer. (or port (config :db-port))))]
-  (when (and user pass)
-    (mongo/authenticate connection user pass))
-  (mongo/set-connection! connection))
-
-(mongo/add-index! :pastes [:user :date])
-(mongo/add-index! :pastes [:private])
-(mongo/add-index! :pastes [:id])
-(mongo/add-index! :pastes [:paste-id])
+(mc/ensure-index "pastes" {:user 1 :date 1})
+(mc/ensure-index "pastes" {:private 1})
+(mc/ensure-index "pastes" {:id 1})
+(mc/ensure-index "pastes" {:paste-id 1})
 
 (server/load-views "src/refheap/views/")
 (server/add-middleware wrap-strip-trailing-slash)

--- a/src/refheap/utilities.clj
+++ b/src/refheap/utilities.clj
@@ -1,6 +1,5 @@
 (ns refheap.utilities
-  (:require [somnium.congomongo :as mongo]
-            [refheap.models.paste :as paste]))
+  (:require [refheap.models.paste :as paste]))
 
 (defn regenerate
   "Regenerates a paste's pygmentized text and preview text from


### PR DESCRIPTION
Basically, shit compiles and nothing obvious breaks:
- Pastes can be created
- Pastes can be viwed
- Pastes can be listed
- Private pastes can be created
- Private pastes can be viewed
- I fixed a minor libnoir migration issue (an outdated require had to be removed)

I am not smart enough to figure out how to get Browser ID work with localhost or where in the UI I can delete a paste but everything was straightforward enough. Please test how the new session store works and if we need to purge the old sessions collection data (I am not sure if `monger.ring.session-store` store works the way the old one does).

Along the way, 3 dependencies are gone: mongo-store, exploding fish, congomongo, all replaced by Monger and what it has out of the box.

There were some minor code changes to work around `monger.collection/insert` behavior (it does not return a map, instead, it returns a write result). I will probably add a new function that will work as CongoMongo's insert
and we can migrate to it.

I also noticed that there is a bunch of places that could dearly benefit from using [Validateur](https://github.com/michaelklishin/validateur). We can migrate to it later.

So, shit mostly works and if something doesn't, I blame it on the lack of a test suite. My codez are obviously perfect.

What are you waiting for? Press that "Merge This Pull Reques" button, now!
