### PR TITLE
Add the Coq language to the list of lexers

### DIFF
--- a/src/refheap/models/paste.clj
+++ b/src/refheap/models/paste.clj
@@ -124,8 +124,7 @@
                  :exts #{"el"}}
    "Coq" {:short "coq"
           :exts #{"v"}}
-   "Verilog" {:short "v"
-              :exts #{"v"}}
+   "Verilog" {:short "v"}
    "Matlab" {:short "matlab"}
    "MuPAD" {:short "mupad"}
    "NumPy" {:short "numpy"}

--- a/src/refheap/models/paste.clj
+++ b/src/refheap/models/paste.clj
@@ -122,6 +122,8 @@
              :exts #{"scm" "ss"}}
    "Emacs Lisp" {:short "scm"
                  :exts #{"el"}}
+   "Coq" {:short "coq"
+          :exts #{"v"}}
    "Verilog" {:short "v"
               :exts #{"v"}}
    "Matlab" {:short "matlab"}


### PR DESCRIPTION
[Coq](http://coq.inria.fr) is an interactive theorem proving language. It uses the same extension `.v` as Verilog. Is this a problem?
