### PR TITLE
Fix python and perl extensions

### DIFF
--- a/src/refheap/highlight.clj
+++ b/src/refheap/highlight.clj
@@ -22,10 +22,10 @@
    "Lua" {:short "lua"
           :exts #{"lua"}}
    "Perl" {:short "perl"
-           :exts #{".pl"}}
+           :exts #{"pl"}}
    "Python Console" {:short "pycon"}
    "Python" {:short "python"
-             :exts #{".py"}}
+             :exts #{"py"}}
    "Python Traceback" {:short "pytb"}
    "Ruby Console" {:short "irb"}
    "Ruby" {:short "ruby"


### PR DESCRIPTION
When using the api the python and perl extensions on the language field had to be `..py` and `..pl` in order to get the language properly identified.
