### PR TITLE
Allow overriding what URL to include in reply.

### DIFF
--- a/src/refheap/models/api.clj
+++ b/src/refheap/models/api.clj
@@ -47,7 +47,7 @@
       (assoc :contents (:raw-contents paste))
       (assoc :user (when-let [user (:user paste)]
                      (:username (users/get-user-by-id user))))
-      (assoc :url (str "https://www.refheap.com/" (:paste-id paste)))
+      (assoc :url (str (or (System/getenv "REPLY_URL") "https://www.refheap.com/") (:paste-id paste)))
       (dissoc :id :_id :raw-contents :summary :history)
       id->paste-id))
 

--- a/src/refheap/models/api.clj
+++ b/src/refheap/models/api.clj
@@ -47,7 +47,7 @@
       (assoc :contents (:raw-contents paste))
       (assoc :user (when-let [user (:user paste)]
                      (:username (users/get-user-by-id user))))
-      (assoc :url (str (or (System/getenv "REPLY_URL") "https://www.refheap.com/") (:paste-id paste)))
+      (assoc :url (str (or (System/getenv "REFHEAP_URL") "https://www.refheap.com/") (:paste-id paste)))
       (dissoc :id :_id :raw-contents :summary :history)
       id->paste-id))
 


### PR DESCRIPTION
For self-hosting and working together with e.g. refheap.el need to return a different base url.
